### PR TITLE
[v1.1.0] - include new features

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        go: ["1.18"]
+        go: ["1.23"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        go: ["1.18"]
+        go: ["1.23"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -55,7 +55,7 @@ jobs:
       - name: setup go server
         uses: actions/setup-go@v1
         with:
-          go-version: "1.19"
+          go-version: "1.23"
       - name: update go.pkg.dev
         env:
           GOPROXY: https://proxy.golang.org

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,79 @@
+# golang-health-checker-lw
+
+## `[1.1.0] - 2024-09-16`
+
+**_Changes_**
+
+- `healthchecker.Integration.Error` struct changed type from `error` to `string`
+- `healthchecker.Config.Concurrence` used to control max paralel routines, default 10
+- Update module golang version from 1.19 -> 1.23
+
+**_Examples_**
+
+```go
+package main
+
+import "github.com/gritzkoo/golang-health-checker-lw"
+
+var checker =  healthchecker.New(healthchecker.healthchecker.Config{
+  Name: "example-app",
+  Version: "v1.1.0",
+  Concurrence: 100, // new attribute to control max paralel routines, default is 10
+  Integrations: []healthchecker.Check{
+    {
+      Name: "example test with error",
+      Handler: func() healthchecker.CheckerResponse {
+        // do your on call or test modules
+        return healthchecker.CheckerResponse{
+          URL: "use to display a reference on response"
+          Error: fmt.Errorf("message if error")
+        }
+      }
+    },
+    {
+      Name: "example test with no error",
+      Handler: func() healthchecker.CheckerResponse {
+        // do your on call or test modules
+        return healthchecker.CheckerResponse{
+          URL: "use to display a reference on response"
+        }
+      }
+    },
+  }
+})
+
+func main(){
+  fmt.Println(checker.Readiness())
+}
+```
+
+---
+
+**_output_**
+
+```log
+{
+  "name": "example-app",
+  "status": false,
+  "version": "v1.1.0",
+  "date": "2024-09-17T11:57:13+02:00",
+  "duration": 1.243803958,
+  "integrations": [
+    {
+      "name": "example test with error",
+      "status": false,
+      "response_time": 1.242491667,
+      "url": "use to display a reference on response",
+      "error": "message if error"
+    },
+    {
+      "name": "example test with no error",
+      "status": true,
+      "response_time": 1.242491667,
+      "url": "use to display a reference on response"
+    },
+  ]
+}
+```
+
+---

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/gritzkoo/golang-health-checker-lw
 
-go 1.19
+go 1.23
 
 require gopkg.in/go-playground/assert.v1 v1.2.1

--- a/pkg/healthchecker/structs.go
+++ b/pkg/healthchecker/structs.go
@@ -30,7 +30,7 @@ type Integration struct {
 	URL string `json:"url"`
 	// The error passed in the CheckResponse.Error
 
-	Error error `json:"error,omitempty"`
+	Error string `json:"error,omitempty"`
 }
 
 // CheckResponse is the main struct to be used outside this package
@@ -103,6 +103,8 @@ type Config struct {
 	// You can place as many functions as you like, then this package will
 	// generate a channel and execute all of the asynchronously
 	Integrations []Check
+	// The ammount of paralel process to execut at once, default is 10
+	Concurrence int
 }
 
 // Check used to inform each integration config


### PR DESCRIPTION
- Add Config.Concurrence to control the amount of pararel routines to be executed
- Changed Integration.Error type from `error` to `string` to return the content of an error instead of a empty object in json responses
- update go version from 1.19 to 1.23

## What does this PR do?

<!-- Describe what this PR is doing -->

## Is this PR a?

- [x] Bugfix
- [x] New Feature
- [ ] BREAKING CHANGES

## This PR will bump?

- [ ] Major
- [x] Minor
- [ ] Patch

## Other pieces of information

<!-- Place more information if you need -->

- fix but in response where when an integration fails, the error always return a empty object because Integration.Error was a type `error`, changed to type `string` and fill with CheckResponse.Error.Error() content
- include `semaphore` to control max pararel routines to avoid resource usage burst.
- upgrade package golang version from 1.19 to 1.23