### PR TITLE
[v1.1.1] - hotfix solving issues with gorotines

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,9 +19,7 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
       - name: test application
-        run: |
-          ls -lRa
-          make test
+        run: make test
       - name: Send coverage to coverall.io
         uses: shogo82148/actions-goveralls@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # golang-health-checker-lw
 
+## `[1.1.1] - 2024-10-06`
+
+**_Changes_**
+
+- `healthchecker.Readiness` **_bug fix_** race conditions: the package test was not covering issues with open threads and race conditions, now the package is thread safe.
+
+
+---
+
 ## `[1.1.0] - 2024-09-16`
 
 **_Changes_**

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test:
-	go test -coverprofile=profile.cov ./...
+	go test -race -coverprofile=profile.cov ./...
 coverage: test
 	go tool cover -html=profile.cov
 build:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ test:
 coverage: test
 	go tool cover -html=profile.cov
 build:
-	CGO_ENABLED=0 GOOS=linux go build -race -a -installsuffix cgo -o healthchecker pkg/**/*.go
+	go build -race -a -installsuffix cgo -o healthchecker pkg/**/*.go
 view-docs:
 	godoc -http=:8331
 run:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ test:
 coverage: test
 	go tool cover -html=profile.cov
 build:
-	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o healthchecker pkg/**/*.go
+	CGO_ENABLED=0 GOOS=linux go build -race -a -installsuffix cgo -o healthchecker pkg/**/*.go
 view-docs:
 	godoc -http=:8331
 run:

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/gritzkoo/golang-health-checker-lw
 
 go 1.23
-
-require gopkg.in/go-playground/assert.v1 v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-gopkg.in/go-playground/assert.v1 v1.2.1 h1:xoYuJVE7KT85PYWrN730RguIQO0ePzVRfFMXadIrXTM=
-gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=

--- a/pkg/healthchecker/healthchecker_test.go
+++ b/pkg/healthchecker/healthchecker_test.go
@@ -6,8 +6,6 @@ import (
 	"net/http"
 	"reflect"
 	"testing"
-
-	"gopkg.in/go-playground/assert.v1"
 )
 
 type CustomError struct {
@@ -29,21 +27,6 @@ var (
 			{
 				Name:   "func 1",
 				Handle: func() CheckResponse { return CheckResponse{} },
-			},
-		},
-	}
-	configSetup4 = Config{
-		Name:    "test 1",
-		Version: "v1",
-		Integrations: []Check{
-			{
-				Name: "func 1",
-				Handle: func() CheckResponse {
-					return CheckResponse{
-						Error: errors.New("Test faild"),
-						URL:   "https://someone-has-failed.com/status",
-					}
-				},
 			},
 		},
 	}
@@ -223,7 +206,10 @@ func TestHealthCheck_Readiness(t *testing.T) {
 				config: tt.fields.config,
 			}
 			got := h.Readiness()
-			assert.Equal(t, got.Status, tt.want.Status)
+			if got.Status != tt.want.Status {
+				t.Errorf("Test Readiness() fail want: %v got: %v", tt.want.Status, got.Status)
+			}
+			// assert.Equal(t, got.Status, tt.want.Status)
 		})
 	}
 }

--- a/pkg/healthchecker/healthchecker_test.go
+++ b/pkg/healthchecker/healthchecker_test.go
@@ -209,7 +209,6 @@ func TestHealthCheck_Readiness(t *testing.T) {
 			if got.Status != tt.want.Status {
 				t.Errorf("Test Readiness() fail want: %v got: %v", tt.want.Status, got.Status)
 			}
-			// assert.Equal(t, got.Status, tt.want.Status)
 		})
 	}
 }


### PR DESCRIPTION
Now the package use `go test -race` comand to trace issues with `go routines`

## What does this PR do?

<!-- Describe what this PR is doing -->

## Is this PR a?

- [x] Bugfix
- [ ] New Feature
- [ ] BREAKING CHANGES

## This PR will bump?

- [ ] Major
- [ ] Minor
- [x] Patch

## Other pieces of information

<!-- Place more information if you need -->
Now the package use test flag `-race` to track issues with gorotines.
A small changes in `healthchecker.Readiness` funcion was made to fix
the current issues of concurrence threads handling `result` variable

